### PR TITLE
Recursive copy docker dir to support agents dir in build

### DIFF
--- a/.bluemix/micro-inventory.pipeline.yml
+++ b/.bluemix/micro-inventory.pipeline.yml
@@ -26,7 +26,7 @@ stages:
         ./gradlew build
         ./gradlew docker
         ls -al docker
-        cp docker/* .
+        cp -R docker/* .
         ls -al $PWD
         echo "Gradle build complete."
 

--- a/.bluemix/micro-socialreview.pipeline.yml
+++ b/.bluemix/micro-socialreview.pipeline.yml
@@ -28,7 +28,7 @@ stages:
         ./gradlew build -x test
         ./gradlew docker
         ls -al docker
-        cp docker/* .
+        cp -R docker/* .
         echo "gradle build done"
 
         # The following colors have been defined to help with presentation of logs: green, red, label_color, no_color.


### PR DESCRIPTION
New Relic and other agent files  are designed to sit in docker/agents/<agent name> 
update cp statement to include subdirectories to support this design
